### PR TITLE
Use Gem::Specification#add_dependency for postmark-rails

### DIFF
--- a/thincloud-postmark.gemspec
+++ b/thincloud-postmark.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "thincloud-test", "~> 0.3.2"
 
-  gem.add_runtime_dependency "postmark-rails", "~> 0.4.1"
+  gem.add_dependency "postmark-rails", "~> 0.4.1"
 end


### PR DESCRIPTION
Make sure that the dependencies come along with thincloud-postmark
during a gem install. Using add_dependency rather than
add_runtime_dependency does just that.
