### PR TITLE
Fixes delivery_method and postmark_settings issue

### DIFF
--- a/test/integration/configuration_test.rb
+++ b/test/integration/configuration_test.rb
@@ -39,4 +39,12 @@ describe Dummy::Application.config do
     it { app_config.delivery_method.must_equal :postmark }
     it { app_config.postmark_settings.must_equal settings }
   end
+
+  describe "updates ActionMailer configuration" do
+    let(:base_config) { ActionMailer::Base }
+    let(:settings) { { api_key: "INITIALIZER" } }
+
+    it { base_config.delivery_method.must_equal :postmark }
+    it { base_config.postmark_settings.must_equal settings }
+  end
 end


### PR DESCRIPTION
The initialization order of Rails runs the 
initializers (config/initializers) after the 
`config.action_mailer` settings have been applied
to ActionMailer::Base. ActionMailer is configured
in `ActiveSupport.on_load(:action_mailer)` like
this `options.each { |k,v| send("#{k}=", v) }`.

This fix applies the tc-postmark settings both
to the application config object and ActionMailer
so it appears normal to the outside world. All of
these settings are applied at the end of the 
initialization process using the `finisher_hook`.
