### PR TITLE
Enable delivery method for specific environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,27 @@ $ gem install thincloud-postmark
 
 ## Usage
 
+Thincloud::Postmark is only enabled for environments included in the `environments` array. For instance, to use `Postmark` in development and staging the list would look like this:
+
+```ruby
+[:development, :staging]
+```
+
+The different configuration options and detailed below.
+
 ### Configuration
 
 Thincloud::Postmark configuration options are available to customize the engine behavior. Available options and their default values:
 
 ```ruby
+# Rails environment(s) that should use the `postmark` delivery method.
+environments              = []
 api_key                   = "POSTMARK_API_TEST"
 interceptor_to            = nil
 interceptor_cc            = nil
 interceptor_bcc           = nil
 
-# Rails environment(s) as a symbol that should have mail intercepted
+# Rails environment(s) that should have mail intercepted.
 interceptor_environments  = []
 ```
 
@@ -76,6 +86,7 @@ The `Thincloud::Postmark` module accepts a `configure` block that takes the same
 
 ```ruby
 Thincloud::Postmark.configure do |config|
+  config.environments   = [:development, :production]
   config.api_key        = "MY_API_KEY"
   config.secure         = true
   config.interceptor_to = "keymaster@zuul.com"
@@ -91,6 +102,7 @@ You can also access the configuration via the Rails configuration object. In fac
 
 ```ruby
 #...
+config.thincloud.postmark.environments = [:development, :production]
 config.thincloud.postmark.api_key = "MY_API_KEY"
 config.thincloud.postmark.secure  = false
 config.thincloud.postmark.interceptor_environments = [:staging]

--- a/lib/thincloud/postmark/configuration.rb
+++ b/lib/thincloud/postmark/configuration.rb
@@ -12,6 +12,7 @@ module Thincloud
 
     # Public: Configuration options for the Thincloud::Postmark module
     class Configuration
+      attr_accessor :environments
       attr_accessor :api_key
       attr_accessor :interceptor_to
       attr_accessor :interceptor_cc
@@ -25,6 +26,7 @@ module Thincloud
         interceptor_cc  = ENV["THINCLOUD_INTERCEPTOR_CC"]
         interceptor_bcc = ENV["THINCLOUD_INTERCEPTOR_BCC"]
 
+        @environments    = []
         @api_key         ||= api_key
         @interceptor_to  ||= interceptor_to
         @interceptor_cc  ||= interceptor_cc

--- a/lib/thincloud/postmark/engine.rb
+++ b/lib/thincloud/postmark/engine.rb
@@ -34,7 +34,10 @@ module Thincloud
       # process to make sure we have our config settings then we apply them
       # to AM::Base. Keep them in both places so config appears normal.
       initializer "thincloud.postmark.settings", before: "finisher_hook" do
-        if configuration.api_key
+        # TODO: Find a way to check other environments in the tests. The dummy
+        # application setup in Rails Engine testing only allows us to test one
+        # environment, :test in this case.
+        if configuration.environments.include?(Rails.env.to_sym)
           [ActionMailer::Base, config.action_mailer].each do |c|
             c.delivery_method   = :postmark
             c.postmark_settings = { api_key: configuration.api_key }

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -4,6 +4,8 @@ describe Thincloud::Postmark::Configuration do
   let(:config) { Thincloud::Postmark::Configuration.new }
 
   it { config.must_be_kind_of Thincloud::Postmark::Configuration }
+  it { config.must_respond_to :environments }
+  it { config.must_respond_to :environments= }
   it { config.must_respond_to :api_key }
   it { config.must_respond_to :api_key= }
   it { config.must_respond_to :secure }
@@ -15,6 +17,7 @@ describe Thincloud::Postmark::Configuration do
   it { config.must_respond_to :interceptor_bcc= }
 
   describe "defaults" do
+    it { config.environments.must_equal [] }
     it { config.api_key.must_equal "POSTMARK_API_TEST" }
     it { config.secure.must_equal true }
     it { ::Postmark.secure.must_equal true }

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -35,6 +35,7 @@ Dummy::Application.configure do
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 
+  config.thincloud.postmark.environments = [:test]
   config.thincloud.postmark.interceptor_environments = [:test]
   config.thincloud.postmark.interceptor_to = "marshmellowman@staypuft.com"
 end


### PR DESCRIPTION
Requires the user specify which environments
should use Postmark for delivery.
